### PR TITLE
I changed from `megacloud.blog` to `megacloud.tv`

### DIFF
--- a/yt_dlp_plugins/extractor/megacloud.py
+++ b/yt_dlp_plugins/extractor/megacloud.py
@@ -471,7 +471,7 @@ class KeyTransform:
         return "".join(result)
 
 class Megacloud:
-    base_url = "https://megacloud.blog"
+    base_url = "https://megacloud.tv"
     headers = {
         "user-agent": "Mozilla/5.0 (X11; Linux x86_64; rv:139.0) Gecko/20100101 Firefox/139.0",
         "origin": base_url,


### PR DESCRIPTION
```
yt-dlp -F "https://kaido.to/watch/my-gift-lvl-9999-unlimited-gacha-backstabbed-in-a-backwater-dungeon-im-out-for-revenge-19908?ep=145496"
[AniWatch] Extracting URL: https://kaido.to/watch/my-gift-lvl-9999-unlimited-gacha-backstabbed-in-a-backwater-dungeon-im-out...enge-19908?ep=145496
[AniWatch] 19908: Fetching Anime Title
Extracting cookies from brave
Attempting to unlock cookies
Extracted 676 cookies from brave
[AniWatch] 19908: Fetching Episode List
[AniWatch] 145496: Fetching Server IDs
[AniWatch] 145496: Getting SUB Episode Information from Vidstreaming
[AniWatch] Failed to extract from Vidstreaming for sub: SOURCE_ID not found, trying next mirror after 10 seconds
[AniWatch] 145496: Getting SUB Episode Information from Vidcloud
[AniWatch] Failed to extract from Vidcloud for sub: SOURCE_ID not found, trying next mirror after 10 seconds
[AniWatch] 145496: Getting DUB Episode Information from Vidstreaming
[AniWatch] Failed to extract from Vidstreaming for dub: SOURCE_ID not found, trying next mirror after 10 seconds
[AniWatch] 145496: Getting DUB Episode Information from Vidcloud
[AniWatch] Failed to extract from Vidcloud for dub: SOURCE_ID not found, trying next mirror after 10 seconds
ERROR: [AniWatch] 145496: No video formats found!; please report this issue on  https://github.com/yt-dlp/yt-dlp/issues?q= , filling out the appropriate issue template. Confirm you are on the late
st version using  yt-dlp -U
```
`VidSrc` and `T-Cloud` not working
```
yt-dlp -F "https://aniwatchtv.to/watch/my-gift-lvl-9999-unlimited-gacha-backstabbed-in-a-backwater-dungeon-im-out-for-revenge-19908?ep=145496"
[AniWatchTV] Extracting URL: https://aniwatchtv.to/watch/my-gift-lvl-9999-unlimited-gacha-backstabbed-in-a-backwater-dungeon-i...enge-19908?ep=145496
[AniWatchTV] 19908: Fetching Anime Title
Extracting cookies from brave
Attempting to unlock cookies
Extracted 675 cookies from brave
[AniWatchTV] 19908: Fetching Episode List
[AniWatchTV] 145496: Fetching Server IDs
[AniWatchTV] 145496: Getting SUB Episode Information from MegaCloud
An error occurred during the request: Expecting value: line 1 column 1 (char 0)
[AniWatchTV] Failed to extract from MegaCloud for sub: Failed to get sources from getSources URL, trying next mirror after 10 seconds
[AniWatchTV] 145496: Getting SUB Episode Information from VidSrc
An error occurred during the request: Expecting value: line 1 column 1 (char 0)
[AniWatchTV] Failed to extract from VidSrc for sub: Failed to get sources from getSources URL, trying next mirror after 10 seconds
[AniWatchTV] 145496: Getting SUB Episode Information from T-Cloud
An error occurred during the request: Expecting value: line 1 column 1 (char 0)
[AniWatchTV] Failed to extract from T-Cloud for sub: Failed to get sources from getSources URL, trying next mirror after 10 seconds
[AniWatchTV] 145496: Getting DUB Episode Information from MegaCloud
An error occurred during the request: Expecting value: line 1 column 1 (char 0)
[AniWatchTV] Failed to extract from MegaCloud for dub: Failed to get sources from getSources URL, trying next mirror after 10 seconds
[AniWatchTV] 145496: Getting DUB Episode Information from VidSrc
An error occurred during the request: Expecting value: line 1 column 1 (char 0)
[AniWatchTV] Failed to extract from VidSrc for dub: Failed to get sources from getSources URL, trying next mirror after 10 seconds
ERROR: [AniWatchTV] 145496: No video formats found!; please report this issue on  https://github.com/yt-dlp/yt-dlp/issues?q= , filling out the appropriate issue template. Confirm you are on the latest version using  yt-dlp -U
```